### PR TITLE
Improve `get_observations` to allow querying by process/object code

### DIFF
--- a/src/probs_runner/endpoint.py
+++ b/src/probs_runner/endpoint.py
@@ -22,8 +22,6 @@ class Observation:
     role: URIRef
     object_: Optional[URIRef] = None
     process: Optional[URIRef] = None
-#    object_code: Optional[str] = None
-#    process_code: Optional[str] = None
     measurement: Optional[float] = None
     bound: URIRef = PROBS.ExactBound
 
@@ -105,7 +103,6 @@ class PRObsEndpoint(RDFoxEndpoint):
             other2 += """
             OPTIONAL { ?obs :processDefinedBy ?process . }"""
         query = self.query_obs_template % (other1, other2)
-        print(query)
         def _convert_measurement(value):
             return float(value) if value is not None else float("nan")
         results = []
@@ -132,19 +129,3 @@ class PRObsEndpoint(RDFoxEndpoint):
                 )
             )
         return results 
-#        return [
-#            Observation(
-#                uri=row["obs"],
-#                time=time,
-#                region=region,
-#                metric=metric,
-#                role=role,
-#                object_=object_,
-#                process=process,
-#                object_code = object_code,
-#                process_code = process_code,
-#                measurement=_convert_measurement(row["measurement"]),
-#                bound=row["bound"],
-#            )
-#            for row in self.query_records(query, initBindings=bindings)
-#        ]

--- a/tests/sample_datasource_simple/load_data.rdfox
+++ b/tests/sample_datasource_simple/load_data.rdfox
@@ -1,5 +1,5 @@
-prefix ufrd: <https://ukfires.org/probs/ontology/raw_data/>
-prefix simple: <https://ukfires.org/probs/ontology/data/simple/>
+prefix ufrd: <http://w3id.org/probs-lab/ontology/raw_data/>
+prefix simple: <http://w3id.org/probs-lab/ontology/data/simple/>
 
 dsource register "Simple"                                           \
     type    delimitedFile                                           \

--- a/tests/sample_datasource_ttl/data.ttl
+++ b/tests/sample_datasource_ttl/data.ttl
@@ -1,4 +1,4 @@
-@prefix probs: <https://ukfires.org/probs/ontology/> .
-@prefix : <https://ukfires.org/probs/ontology/data/simple/> .
+@prefix probs: <http://w3id.org/probs-lab/ontology/> .
+@prefix : <http://w3id.org/probs-lab/ontology/data/simple/> .
 
 :Object-Bread probs:hasValue "6.0"^^xsd:double .

--- a/tests/test_probs_endpoint.py
+++ b/tests/test_probs_endpoint.py
@@ -14,15 +14,15 @@ from probs_runner import (
 )
 
 
-NS = Namespace("https://ukfires.org/probs/ontology/data/simple/")
+NS = Namespace("http://w3id.org/probs-lab/ontology/data/simple/")
 
 def test_probs_endpoint(tmp_path, script_source_dir):
     output_filename = tmp_path / "output.nt.gz"
     with gzip.open(output_filename, "wt") as f:
         f.writelines(
             [
-                '<https://ukfires.org/probs/ontology/data/simple/Object-Bread> <http://w3id.org/probs-lab/ontology/hasValue> "6"^^<http://www.w3.org/2001/XMLSchema#double> .',
-                '<https://ukfires.org/probs/ontology/data/simple/Object-Cake> <http://w3id.org/probs-lab/ontology/hasValue> "3"^^<http://www.w3.org/2001/XMLSchema#double> .',
+                '<http://w3id.org/probs-lab/ontology/data/simple/Object-Bread> <http://w3id.org/probs-lab/ontology/hasValue> "6"^^<http://www.w3.org/2001/XMLSchema#double> .',
+                '<http://w3id.org/probs-lab/ontology/data/simple/Object-Cake> <http://w3id.org/probs-lab/ontology/hasValue> "3"^^<http://www.w3.org/2001/XMLSchema#double> .',
             ]
         )
 
@@ -152,7 +152,7 @@ def test_probs_endpoint_get_observations_by_process_code(tmp_path, script_source
         ]
 
         result2 = rdfox.get_observations(
-            time=PROBS.TimePeriod_YearOf2030,
+            time=PROBS.TimePeriod_YearOf2018,
             region=PROBS.RegionGBR,
             metric=QUANTITYKIND.Mass,
             role=PROBS.ProcessOutput,
@@ -217,7 +217,7 @@ def test_probs_endpoint_get_observations_by_object_code(tmp_path, script_source_
             region=PROBS.RegionGBR,
             metric=QUANTITYKIND.Mass,
             role=PROBS.SoldProduction,
-            object_=URIRef("http://example.org/unfccc/N2O"),
+            object_code="2345",
         )
 
         assert result2 == []

--- a/tests/test_probs_endpoint.py
+++ b/tests/test_probs_endpoint.py
@@ -145,7 +145,7 @@ def test_probs_endpoint_get_observations_by_process_code(tmp_path, script_source
                 metric=QUANTITYKIND.Mass,
                 role=PROBS.ProcessOutput,
                 object_=URIRef("http://example.org/unfccc/N2O"),
-                process_code="1_with_LULUCF",
+                process=URIRef("http://example.org/unfccc/1."),
                 measurement=8551330,
                 bound=PROBS.ExactBound,
             )
@@ -156,9 +156,71 @@ def test_probs_endpoint_get_observations_by_process_code(tmp_path, script_source
             region=PROBS.RegionGBR,
             metric=QUANTITYKIND.Mass,
             role=PROBS.ProcessOutput,
-            object_=URIRef("http://c-thru.org/data/external/unfccc/N2O"),
-            process=URIRef("http://c-thru.org/data/external/unfccc/1."),
+            object_=URIRef("http://example.org/unfccc/N2O"),
+            process_code="2_with_LULUCF",
         )
 
         assert result2 == []
+
+
+
+def test_probs_endpoint_get_observations_by_object_code(tmp_path, script_source_dir):
+    output_filename = tmp_path / "output.nt.gz"
+    with gzip.open(output_filename, "wt") as f:
+        f.write("""
+<http://example.org/Obs> <http://w3id.org/probs-lab/ontology/measurement> "8551330"^^<http://www.w3.org/2001/XMLSchema#double> .
+<http://example.org/Obs> <http://w3id.org/probs-lab/ontology/objectDefinedBy> <http://example.org/prodcom/Object-1234> .
+<http://example.org/Obs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://w3id.org/probs-lab/ontology/DirectObservation> .
+<http://example.org/Obs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/prov#Entity> .
+<http://example.org/Obs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://w3id.org/probs-lab/ontology/Observation> .
+<http://example.org/Obs> <http://w3id.org/probs-lab/ontology/metric> <http://qudt.org/vocab/quantitykind/Mass> .
+<http://example.org/Obs> <http://w3id.org/probs-lab/ontology/bound> <http://w3id.org/probs-lab/ontology/ExactBound> .
+<http://example.org/Obs> <http://w3id.org/probs-lab/ontology/partOfDataset> <http://example.org/prodcom/PRODCOM2016DATA> .
+<http://example.org/Obs> <http://w3id.org/probs-lab/ontology/objectDirectlyDefinedBy> <http://example.org/prodcom/Object-1234> .
+<http://example.org/Obs> <http://w3id.org/probs-lab/ontology/hasRole> <http://w3id.org/probs-lab/ontology/SoldProduction> .
+<http://example.org/Obs> <http://w3id.org/probs-lab/ontology/hasTimePeriod> <http://w3id.org/probs-lab/ontology/TimePeriod_YearOf2016> .
+<http://example.org/Obs> <http://w3id.org/probs-lab/ontology/hasRegion> <http://w3id.org/probs-lab/ontology/RegionGBR> .
+<http://example.org/prodcom/Object-1234> <http://w3id.org/probs-lab/ontology/hasClassificationCode> <http://example.org/prodcom/2016/ClassificationCode-1234> .
+<http://example.org/prodcom/Object-1234> <http://w3id.org/probs-lab/ontology/objectName> "PRODCOM Object corresponding to Code 1234" .
+<http://example.org/prodcom/2016/ClassificationCode-1234> <http://w3id.org/probs-lab/ontology/codeDescription> "An test PRODCOM commodity" .
+<http://example.org/prodcom/2016/ClassificationCode-1234> <http://w3id.org/probs-lab/ontology/codeName> "1234" .
+<http://example.org/prodcom/2016/ClassificationCode-1234> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/prodcom/ClassificationCode> .
+        """)
+
+
+    with probs_endpoint(
+        output_filename, tmp_path, script_source_dir, port=12159
+    ) as rdfox:
+        result = rdfox.get_observations(
+            time=PROBS.TimePeriod_YearOf2016,
+            region=PROBS.RegionGBR,
+            metric=QUANTITYKIND.Mass,
+            role=PROBS.SoldProduction,
+            object_code="1234",
+        )
+
+        assert result == [
+            Observation(
+                uri=URIRef("http://example.org/Obs"),
+                time=PROBS.TimePeriod_YearOf2016,
+                region=PROBS.RegionGBR,
+                metric=QUANTITYKIND.Mass,
+                role=PROBS.SoldProduction,
+                object_=URIRef("http://example.org/prodcom/Object-1234"),
+                measurement=8551330,
+                bound=PROBS.ExactBound,
+            )
+        ]
+
+        result2 = rdfox.get_observations(
+            time=PROBS.TimePeriod_YearOf2016,
+            region=PROBS.RegionGBR,
+            metric=QUANTITYKIND.Mass,
+            role=PROBS.SoldProduction,
+            object_=URIRef("http://example.org/unfccc/N2O"),
+        )
+
+        assert result2 == []
+
+
 

--- a/tests/test_probs_endpoint.py
+++ b/tests/test_probs_endpoint.py
@@ -16,14 +16,13 @@ from probs_runner import (
 
 NS = Namespace("https://ukfires.org/probs/ontology/data/simple/")
 
-
 def test_probs_endpoint(tmp_path, script_source_dir):
     output_filename = tmp_path / "output.nt.gz"
     with gzip.open(output_filename, "wt") as f:
         f.writelines(
             [
-                '<https://ukfires.org/probs/ontology/data/simple/Object-Bread> <https://ukfires.org/probs/ontology/hasValue> "6"^^<http://www.w3.org/2001/XMLSchema#double> .',
-                '<https://ukfires.org/probs/ontology/data/simple/Object-Cake> <https://ukfires.org/probs/ontology/hasValue> "3"^^<http://www.w3.org/2001/XMLSchema#double> .',
+                '<https://ukfires.org/probs/ontology/data/simple/Object-Bread> <http://w3id.org/probs-lab/ontology/hasValue> "6"^^<http://www.w3.org/2001/XMLSchema#double> .',
+                '<https://ukfires.org/probs/ontology/data/simple/Object-Cake> <http://w3id.org/probs-lab/ontology/hasValue> "3"^^<http://www.w3.org/2001/XMLSchema#double> .',
             ]
         )
 
@@ -48,21 +47,22 @@ def test_probs_endpoint_get_observations(tmp_path, script_source_dir):
     output_filename = tmp_path / "output.nt.gz"
     with gzip.open(output_filename, "wt") as f:
         f.write("""
-<http://example.org/Obs> <https://ukfires.org/probs/ontology/measurement> "8551330"^^<http://www.w3.org/2001/XMLSchema#double> .
-<http://example.org/Obs> <https://ukfires.org/probs/ontology/objectDefinedBy> <http://example.org/unfccc/N2O> .
-<http://example.org/Obs> <https://ukfires.org/probs/ontology/processDefinedBy> <http://example.org/unfccc/1.> .
-<http://example.org/Obs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://ukfires.org/probs/ontology/DirectObservation> .
+<http://example.org/Obs> <http://w3id.org/probs-lab/ontology/measurement> "8551330"^^<http://www.w3.org/2001/XMLSchema#double> .
+<http://example.org/Obs> <http://w3id.org/probs-lab/ontology/objectDefinedBy> <http://example.org/unfccc/N2O> .
+<http://example.org/Obs> <http://w3id.org/probs-lab/ontology/processDefinedBy> <http://example.org/unfccc/1.> .
+<http://example.org/Obs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://w3id.org/probs-lab/ontology/DirectObservation> .
 <http://example.org/Obs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/prov#Entity> .
-<http://example.org/Obs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://ukfires.org/probs/ontology/Observation> .
-<http://example.org/Obs> <https://ukfires.org/probs/ontology/metric> <http://qudt.org/vocab/quantitykind/Mass> .
-<http://example.org/Obs> <https://ukfires.org/probs/ontology/bound> <https://ukfires.org/probs/ontology/ExactBound> .
-<http://example.org/Obs> <https://ukfires.org/probs/ontology/partOfDataset> <http://example.org/unfccc/UNFCCCData> .
-<http://example.org/Obs> <https://ukfires.org/probs/ontology/objectDirectlyDefinedBy> <http://example.org/unfccc/N2O> .
-<http://example.org/Obs> <https://ukfires.org/probs/ontology/processDirectlyDefinedBy> <http://example.org/unfccc/1.> .
-<http://example.org/Obs> <https://ukfires.org/probs/ontology/hasRole> <https://ukfires.org/probs/ontology/ProcessOutput> .
-<http://example.org/Obs> <https://ukfires.org/probs/ontology/hasTimePeriod> <https://ukfires.org/probs/ontology/TimePeriod_YearOf2018> .
-<http://example.org/Obs> <https://ukfires.org/probs/ontology/hasRegion> <https://ukfires.org/probs/ontology/RegionGBR> .
+<http://example.org/Obs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://w3id.org/probs-lab/ontology/Observation> .
+<http://example.org/Obs> <http://w3id.org/probs-lab/ontology/metric> <http://qudt.org/vocab/quantitykind/Mass> .
+<http://example.org/Obs> <http://w3id.org/probs-lab/ontology/bound> <http://w3id.org/probs-lab/ontology/ExactBound> .
+<http://example.org/Obs> <http://w3id.org/probs-lab/ontology/partOfDataset> <http://example.org/unfccc/UNFCCCData> .
+<http://example.org/Obs> <http://w3id.org/probs-lab/ontology/objectDirectlyDefinedBy> <http://example.org/unfccc/N2O> .
+<http://example.org/Obs> <http://w3id.org/probs-lab/ontology/processDirectlyDefinedBy> <http://example.org/unfccc/1.> .
+<http://example.org/Obs> <http://w3id.org/probs-lab/ontology/hasRole> <http://w3id.org/probs-lab/ontology/ProcessOutput> .
+<http://example.org/Obs> <http://w3id.org/probs-lab/ontology/hasTimePeriod> <http://w3id.org/probs-lab/ontology/TimePeriod_YearOf2018> .
+<http://example.org/Obs> <http://w3id.org/probs-lab/ontology/hasRegion> <http://w3id.org/probs-lab/ontology/RegionGBR> .
         """)
+
 
     with probs_endpoint(
         output_filename, tmp_path, script_source_dir, port=12159
@@ -100,3 +100,65 @@ def test_probs_endpoint_get_observations(tmp_path, script_source_dir):
         )
 
         assert result2 == []
+
+
+def test_probs_endpoint_get_observations_by_process_code(tmp_path, script_source_dir):
+    output_filename = tmp_path / "output.nt.gz"
+    with gzip.open(output_filename, "wt") as f:
+        f.write("""
+<http://example.org/Obs> <http://w3id.org/probs-lab/ontology/measurement> "8551330"^^<http://www.w3.org/2001/XMLSchema#double> .
+<http://example.org/Obs> <http://w3id.org/probs-lab/ontology/objectDefinedBy> <http://example.org/unfccc/N2O> .
+<http://example.org/Obs> <http://w3id.org/probs-lab/ontology/processDefinedBy> <http://example.org/unfccc/1.> .
+<http://example.org/unfccc/1.> <http://w3id.org/probs-lab/ontology/processName> "1.  Energy>" .
+<http://example.org/unfccc/1.> <http://w3id.org/probs-lab/ontology/codeName> "1_with_LULUCF" .
+<http://example.org/Obs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://w3id.org/probs-lab/ontology/DirectObservation> .
+<http://example.org/Obs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/prov#Entity> .
+<http://example.org/Obs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://w3id.org/probs-lab/ontology/Observation> .
+<http://example.org/Obs> <http://w3id.org/probs-lab/ontology/metric> <http://qudt.org/vocab/quantitykind/Mass> .
+<http://example.org/Obs> <http://w3id.org/probs-lab/ontology/bound> <http://w3id.org/probs-lab/ontology/ExactBound> .
+<http://example.org/Obs> <http://w3id.org/probs-lab/ontology/partOfDataset> <http://example.org/unfccc/UNFCCCData> .
+<http://example.org/Obs> <http://w3id.org/probs-lab/ontology/objectDirectlyDefinedBy> <http://example.org/unfccc/N2O> .
+<http://example.org/Obs> <http://w3id.org/probs-lab/ontology/processDirectlyDefinedBy> <http://example.org/unfccc/1.> .
+<http://example.org/Obs> <http://w3id.org/probs-lab/ontology/hasRole> <http://w3id.org/probs-lab/ontology/ProcessOutput> .
+<http://example.org/Obs> <http://w3id.org/probs-lab/ontology/hasTimePeriod> <http://w3id.org/probs-lab/ontology/TimePeriod_YearOf2018> .
+<http://example.org/Obs> <http://w3id.org/probs-lab/ontology/hasRegion> <http://w3id.org/probs-lab/ontology/RegionGBR> .
+        """)
+
+
+    with probs_endpoint(
+        output_filename, tmp_path, script_source_dir, port=12159
+    ) as rdfox:
+        result = rdfox.get_observations(
+            time=PROBS.TimePeriod_YearOf2018,
+            region=PROBS.RegionGBR,
+            metric=QUANTITYKIND.Mass,
+            role=PROBS.ProcessOutput,
+            object_=URIRef("http://example.org/unfccc/N2O"),
+            process_code= "1_with_LULUCF",
+        )
+
+        assert result == [
+            Observation(
+                uri=URIRef("http://example.org/Obs"),
+                time=PROBS.TimePeriod_YearOf2018,
+                region=PROBS.RegionGBR,
+                metric=QUANTITYKIND.Mass,
+                role=PROBS.ProcessOutput,
+                object_=URIRef("http://example.org/unfccc/N2O"),
+                process_code="1_with_LULUCF",
+                measurement=8551330,
+                bound=PROBS.ExactBound,
+            )
+        ]
+
+        result2 = rdfox.get_observations(
+            time=PROBS.TimePeriod_YearOf2030,
+            region=PROBS.RegionGBR,
+            metric=QUANTITYKIND.Mass,
+            role=PROBS.ProcessOutput,
+            object_=URIRef("http://c-thru.org/data/external/unfccc/N2O"),
+            process=URIRef("http://c-thru.org/data/external/unfccc/1."),
+        )
+
+        assert result2 == []
+

--- a/tests/test_probs_runner.py
+++ b/tests/test_probs_runner.py
@@ -16,7 +16,8 @@ from probs_runner import (
 )
 
 
-NS = Namespace("https://ukfires.org/probs/ontology/data/simple/")
+#NS = Namespace("https://ukfires.org/probs/ontology/data/simple/")
+NS = Namespace("http://w3id.org/probs-lab/ontology/data/simple/")
 
 
 def test_convert_data_csv(tmp_path, script_source_dir):
@@ -102,7 +103,7 @@ def test_enhance_data(tmp_path, script_source_dir):
     with gzip.open(original_filename, "wt") as f:
         f.write(
             """
-<https://ukfires.org/probs/ontology/data/simple/Object-Bread> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://ukfires.org/probs/ontology/Object> .
+<http://w3id.org/probs-lab/ontology/data/simple/Object-Bread> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://w3id.org/probs-lab/ontology/Object> .
         """
         )
 
@@ -125,7 +126,7 @@ def _setup_test_nt_gz_data(p, object_name):
     with gzip.open(p, "wt") as f:
         f.write(
             f"""
-<https://ukfires.org/probs/ontology/data/simple/{object_name}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://ukfires.org/probs/ontology/Object> .
+<http://w3id.org/probs-lab/ontology/data/simple/{object_name}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://w3id.org/probs-lab/ontology/Object> .
 """
         )
 
@@ -135,8 +136,8 @@ def _setup_test_ttl_data(p, object_name):
     with open(p, "wt") as f:
         f.write(
             f"""
-@prefix simple: <https://ukfires.org/probs/ontology/data/simple/> .
-@prefix probs: <https://ukfires.org/probs/ontology/> .
+@prefix simple: <http://w3id.org/probs-lab/ontology/data/simple/> .
+@prefix probs: <http://w3id.org/probs-lab/ontology/> .
 simple:{object_name} a probs:Object .
 """
         )
@@ -206,8 +207,8 @@ def test_probs_endpoint(tmp_path, script_source_dir):
     with gzip.open(output_filename, "wt") as f:
         f.writelines(
             [
-                '<https://ukfires.org/probs/ontology/data/simple/Object-Bread> <https://ukfires.org/probs/ontology/hasValue> "6"^^<http://www.w3.org/2001/XMLSchema#double> .',
-                '<https://ukfires.org/probs/ontology/data/simple/Object-Cake> <https://ukfires.org/probs/ontology/hasValue> "3"^^<http://www.w3.org/2001/XMLSchema#double> .',
+                '<http://w3id.org/probs-lab/ontology/data/simple/Object-Bread> <http://w3id.org/probs-lab/ontology/hasValue> "6"^^<http://www.w3.org/2001/XMLSchema#double> .',
+                '<http://w3id.org/probs-lab/ontology/data/simple/Object-Cake> <http://w3id.org/probs-lab/ontology/hasValue> "3"^^<http://www.w3.org/2001/XMLSchema#double> .',
             ]
         )
 


### PR DESCRIPTION
This is useful to improve unit tests and avoid relying on calculating the object IRI involving a hash.