### PR TITLE
Sjb validate only

### DIFF
--- a/src/probs_runner/cli.py
+++ b/src/probs_runner/cli.py
@@ -108,15 +108,11 @@ def validate_data(obj, inputs):
     script_source_dir = obj["script_source_dir"]
     errors = probs_validate_data(inputs, working_dir, script_source_dir)
 
-    if not errors:
+    if errors == 0:
         click.echo(f"Validation passed", err=True)
-        sys.exit(0)
     else:
         click.echo(f"Validation failed", err=True)
-        for error_type in errors.keys():
-            click.echo(f"{error_type}:", err=True)
-            click.echo(f"{errors[error_type]}", err=True)
-        sys.exit(1)
+    sys.exit(errors)
     
 
 @cli.command()

--- a/src/probs_runner/cli.py
+++ b/src/probs_runner/cli.py
@@ -97,8 +97,10 @@ def convert_ontology(obj, ontology, output):
 
 @cli.command()
 @click.argument("inputs", nargs=-1, type=click.Path(exists=True, path_type=pathlib.Path))
+@click.option("--debug/--no-debug", help="Debug RDF data", default=False)
+@click.option("--output", help="Output folder for log files", nargs=1, type=click.Path(exists=True, path_type=pathlib.Path))
 @click.pass_obj
-def validate_data(obj, inputs):
+def validate_data(obj, inputs, debug, output):
     "Validate converted RDF data."
 
     click.echo(f"Checking {len(inputs)} input{'s' if len(inputs) > 1 else ''}...", err=True)
@@ -106,7 +108,7 @@ def validate_data(obj, inputs):
     # Load data sources
     working_dir = obj["working_dir"]
     script_source_dir = obj["script_source_dir"]
-    errors = probs_validate_data(inputs, working_dir, script_source_dir)
+    errors = probs_validate_data(inputs, working_dir, script_source_dir, debug=debug, output_path=output)
 
     if errors == 0:
         click.echo(f"Validation passed", err=True)

--- a/src/probs_runner/cli.py
+++ b/src/probs_runner/cli.py
@@ -97,10 +97,9 @@ def convert_ontology(obj, ontology, output):
 
 @cli.command()
 @click.argument("inputs", nargs=-1, type=click.Path(exists=True, path_type=pathlib.Path))
-@click.option("--debug/--no-debug", help="Debug RDF data", default=False)
-@click.option("--output", help="Output folder for log files", nargs=1, type=click.Path(exists=True, path_type=pathlib.Path))
+@click.option("--debug-files", help="Output folder for debug log files", nargs=1, type=click.Path(exists=True, path_type=pathlib.Path))
 @click.pass_obj
-def validate_data(obj, inputs, debug, output):
+def validate_data(obj, inputs, debug_files):
     "Validate converted RDF data."
 
     click.echo(f"Checking {len(inputs)} input{'s' if len(inputs) > 1 else ''}...", err=True)
@@ -108,7 +107,7 @@ def validate_data(obj, inputs, debug, output):
     # Load data sources
     working_dir = obj["working_dir"]
     script_source_dir = obj["script_source_dir"]
-    errors = probs_validate_data(inputs, working_dir, script_source_dir, debug=debug, output_path=output)
+    errors = probs_validate_data(inputs, working_dir, script_source_dir, debug_files=debug_files)
 
     if errors == 0:
         click.echo(f"Validation passed", err=True)

--- a/src/probs_runner/cli.py
+++ b/src/probs_runner/cli.py
@@ -107,13 +107,14 @@ def validate_data(obj, inputs, debug_files):
     # Load data sources
     working_dir = obj["working_dir"]
     script_source_dir = obj["script_source_dir"]
-    errors = probs_validate_data(inputs, working_dir, script_source_dir, debug_files=debug_files)
+    valid = probs_validate_data(inputs, working_dir, script_source_dir, debug_files=debug_files)
 
-    if errors == 0:
+    if valid:
         click.echo(f"Validation passed", err=True)
+        sys.exit(0)
     else:
         click.echo(f"Validation failed", err=True)
-    sys.exit(errors)
+        sys.exit(1)
     
 
 @cli.command()

--- a/src/probs_runner/runners.py
+++ b/src/probs_runner/runners.py
@@ -322,6 +322,7 @@ def probs_validate_data(
     working_dir: Optional[Union[os.PathLike, str]] = None,
     script_source_dir: Optional[Union[os.PathLike, str]] = None,
     debug: Optional[bool] = False,
+    output_path: Optional[Union[os.PathLike, str]] = None,
 ) -> int:
     """Load `original_data_path`, run data validation script.
 
@@ -330,12 +331,16 @@ def probs_validate_data(
     :param working_dir: Path to setup runner in, defaults to a temporary directory
     :param script_source_dir: Path to copy scripts from
     :param debug: Output .log files listing problems in data 
+    :param output_path: Path to folder for log files, defaults to current directory
     """
-    
+
     if debug:
         debug_param = "debug"
     else:
         debug_param = ""
+
+    if output_path == None:
+        output_path = Path.cwd() 
 
     setup_script = [
         # FIXME This is abusing the RDFox arguments, but it turns out that it
@@ -355,7 +360,10 @@ def probs_validate_data(
 
     with runner:
         logger.debug("probs_validate_data: RDFox runner done")
+        for output_file in runner.files("data").glob("test_*.log"):
+            copy_from_rdfox(output_file, output_path)
         output_file = runner.files("data") / "valid.log"
+        copy_from_rdfox(output_file, output_path)
         result = output_file.read_text().splitlines()
         if result[1] == "true":
             return 0

--- a/src/probs_runner/runners.py
+++ b/src/probs_runner/runners.py
@@ -321,7 +321,7 @@ def probs_validate_data(
     datasources: AllowableDataInputs,
     working_dir: Optional[Union[os.PathLike, str]] = None,
     script_source_dir: Optional[Union[os.PathLike, str]] = None,
-) -> Dict[str, str]:
+) -> int:
     """Load `original_data_path`, run data validation script.
 
     :param datasources: List of :py:class:`Datasource` objects describing
@@ -336,17 +336,16 @@ def probs_validate_data(
         working_dir=working_dir,
         script_source_dir=script_source_dir,
     )
-    errors = {}
+
     with runner:
         logger.debug("probs_validate_data: RDFox runner done")
-        for output_file in runner.files("data").glob("test_*.log"):
-            test_name = output_file.stem.replace("test_", "") # filename without extension
-            result = output_file.read_text()
-            if len(result.splitlines()) > 1:
-                result = ''.join(result.splitlines(keepends=True)[1:]) # Remove header
-                errors[test_name] = result
+        output_file = runner.files("data") / "valid.log"
+        result = output_file.read_text().splitlines()
+        if result[1] == "true":
+            return 0
+        else:
+            return 1 
 
-    return errors
 
 def probs_enhance_data(
     datasources: AllowableDataInputs,

--- a/src/probs_runner/runners.py
+++ b/src/probs_runner/runners.py
@@ -362,9 +362,9 @@ def probs_validate_data(
             for output_file in runner.files("data").glob("test_*.log"):
                 copy_from_rdfox(output_file, debug_files)
         if result[1] == "true":
-            return 0
+            return True
         else:
-            return 1 
+            return False 
 
 
 def probs_enhance_data(

--- a/src/probs_runner/runners.py
+++ b/src/probs_runner/runners.py
@@ -321,6 +321,7 @@ def probs_validate_data(
     datasources: AllowableDataInputs,
     working_dir: Optional[Union[os.PathLike, str]] = None,
     script_source_dir: Optional[Union[os.PathLike, str]] = None,
+    debug: Optional[bool] = False,
 ) -> int:
     """Load `original_data_path`, run data validation script.
 
@@ -328,11 +329,26 @@ def probs_validate_data(
     inputs, or paths to individual input files.
     :param working_dir: Path to setup runner in, defaults to a temporary directory
     :param script_source_dir: Path to copy scripts from
+    :param debug: Output .log files listing problems in data 
     """
+    
+    if debug:
+        debug_param = "debug"
+    else:
+        debug_param = ""
+
+    setup_script = [
+        # FIXME This is abusing the RDFox arguments, but it turns out that it
+        # works to set a variable called "1" before calling an RDFox script with
+        # no positional arguments, and the value of this variable appears as if
+        # it was a positional argument.
+        f'set 1 "{debug_param or ""}"'
+    ]
 
     runner = probs_run_module(
         "data-validation",
         datasources,
+        setup_script=setup_script,
         working_dir=working_dir,
         script_source_dir=script_source_dir,
     )

--- a/src/probs_runner/runners.py
+++ b/src/probs_runner/runners.py
@@ -321,8 +321,7 @@ def probs_validate_data(
     datasources: AllowableDataInputs,
     working_dir: Optional[Union[os.PathLike, str]] = None,
     script_source_dir: Optional[Union[os.PathLike, str]] = None,
-    debug: Optional[bool] = False,
-    output_path: Optional[Union[os.PathLike, str]] = None,
+    debug_files: Optional[Union[os.PathLike, str]] = None,
 ) -> int:
     """Load `original_data_path`, run data validation script.
 
@@ -330,17 +329,13 @@ def probs_validate_data(
     inputs, or paths to individual input files.
     :param working_dir: Path to setup runner in, defaults to a temporary directory
     :param script_source_dir: Path to copy scripts from
-    :param debug: Output .log files listing problems in data 
-    :param output_path: Path to folder for log files, defaults to current directory
+    :param debug_files: Path to folder for debug log files, defaults to no debugging
     """
 
-    if debug:
-        debug_param = "debug"
-    else:
+    if debug_files == None:
         debug_param = ""
-
-    if output_path == None:
-        output_path = Path.cwd() 
+    else:
+        debug_param = "debug"
 
     setup_script = [
         # FIXME This is abusing the RDFox arguments, but it turns out that it
@@ -360,11 +355,12 @@ def probs_validate_data(
 
     with runner:
         logger.debug("probs_validate_data: RDFox runner done")
-        for output_file in runner.files("data").glob("test_*.log"):
-            copy_from_rdfox(output_file, output_path)
         output_file = runner.files("data") / "valid.log"
-        copy_from_rdfox(output_file, output_path)
         result = output_file.read_text().splitlines()
+        if debug_files != None:
+            copy_from_rdfox(output_file, debug_files)
+            for output_file in runner.files("data").glob("test_*.log"):
+                copy_from_rdfox(output_file, debug_files)
         if result[1] == "true":
             return 0
         else:

--- a/src/probs_runner/runners.py
+++ b/src/probs_runner/runners.py
@@ -322,7 +322,7 @@ def probs_validate_data(
     working_dir: Optional[Union[os.PathLike, str]] = None,
     script_source_dir: Optional[Union[os.PathLike, str]] = None,
     debug_files: Optional[Union[os.PathLike, str]] = None,
-) -> int:
+) -> bool:
     """Load `original_data_path`, run data validation script.
 
     :param datasources: List of :py:class:`Datasource` objects describing


### PR DESCRIPTION
@ricklupton 

Incorporates changes need for updated version of ```probs-module-data-validation```.

Optional parameters specifying whether to run scripts in ```debug``` mode (to generate extra log files with information on possible errors in RDF data) and to specify folder for log files (defaults to current working directory): 

https://github.com/probs-lab/probs-runner/blob/sjb-validate-only/src/probs_runner/runners.py#L324C1-L325C59

If in debug mode uses ```setup_script``` parameter to ```set 1 "debug"``` in RDFox:

https://github.com/probs-lab/probs-runner/blob/sjb-validate-only/src/probs_runner/runners.py#L345C1-L351C6


```probs-validate-data``` in ```runners.py``` will return 0 if valid, 1 if fail.

```cli.py``` altered to to use new parameters, e.g.  ```probs-runner validate-data test.nt.gz --debug --output test_logs```


https://github.com/probs-lab/probs-runner/blob/sjb-validate-only/src/probs_runner/cli.py#L100C1-L101C125

 
